### PR TITLE
Updated bower primary acting file paths

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
   "authors": [
     "Geremia Taglialatela"
   ],
-  "main": ["kalendae.standalone.min.js", "kalendae.css"],
+  "main": ["build/kalendae.standalone.min.js", "build/kalendae.css"],
   "description": "A framework agnostic javascript date picker.",
   "keywords": [
     "datepicker",


### PR DESCRIPTION
From [bower docs](https://github.com/bower/bower.json-spec#main): 

"The primary acting files necessary to use your package. While Bower does not directly use these files, they are listed with the commands bower list --json and bower list --paths, so they can be used by build tools."

I updated paths to `build/*` to now work with build tools such as Gulp.js etc.
